### PR TITLE
add sortInstruments function to get cheapest/most recent instruments

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -23,7 +23,7 @@ function sortByMintedAt(instruments) {
   instruments.sort((a, b) => {
     return a.instrument.minted_at - b.instrument.minted_at
   })
-  return instruments[instruments.length - 1]
+  return instruments
 }
 
 function sortByCheapestRight(instruments, rightName){
@@ -149,13 +149,15 @@ function sortInstruments(instruments, rightName, sortOrder = "cheapestThenMostRe
 
       // if more than one instrument has the same price for the right, get the most recently updated
       if (cheapestInstruments.length > 0) {
-        return sortByMintedAt(cheapestInstruments)
+        sortedInstruments = sortByMintedAt(cheapestInstruments)
+        return sortedInstruments[sortedInstruments.length - 1]
       }
 
       return cheapestInstrument
 
     case sortTypes[2]:    
-      return sortByMintedAt(instruments)
+      sortedInstruments = sortByMintedAt(instruments)
+      return sortedInstruments[sortedInstruments.length - 1]
   }
 }
 

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -146,19 +146,13 @@ function sortInstruments(instruments, rightName, sortOrder = "cheapestThenMostRe
       cheapestInstrument = sortedInstruments[0]
       cheapestPrice = this.getRight(cheapestInstrument, rightName).price_in_cpu;
       cheapestInstruments = sortedInstruments.filter(instrument => this.getRight(instrument, rightName).price_in_cpu === cheapestPrice)
-
-      // if more than one instrument has the same price for the right, get the most recently updated
-      if (cheapestInstruments.length > 0) {
-        sortedInstruments = sortByMintedAt(cheapestInstruments)
-        return sortedInstruments[sortedInstruments.length - 1]
-      }
-
-      return cheapestInstrument
+      
+      sortedInstruments = sortByMintedAt(cheapestInstruments)
 
     case sortTypes[2]:    
       sortedInstruments = sortByMintedAt(instruments)
-      return sortedInstruments[sortedInstruments.length - 1]
   }
+  return sortedInstruments[sortedInstruments.length - 1]
 }
 
 module.exports = {

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -142,9 +142,7 @@ function sortInstruments(instruments, rightName, sortOrder = "cheapestThenMostRe
 
   switch (sortOrder) {
     case sortTypes[1]:
-    
       sortedInstruments = sortByCheapestRight.bind(this)(instruments, rightName)
-      
       cheapestInstrument = sortedInstruments[0]
       cheapestPrice = this.getRight(cheapestInstrument, rightName).price_in_cpu;
       cheapestInstruments = sortedInstruments.filter(instrument => this.getRight(instrument, rightName).price_in_cpu === cheapestPrice)
@@ -153,11 +151,11 @@ function sortInstruments(instruments, rightName, sortOrder = "cheapestThenMostRe
       if (cheapestInstruments.length > 0) {
         return sortByMintedAt(cheapestInstruments)
       }
-      
+
       return cheapestInstrument
 
     case sortTypes[2]:    
-    return sortByMintedAt(instruments)
+      return sortByMintedAt(instruments)
   }
 }
 

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -26,6 +26,16 @@ function sortByMintedAt(instruments) {
   return instruments[instruments.length - 1]
 }
 
+function sortByCheapestRight(instruments, rightName){
+  // sorts the instruments by the price for the right
+  instruments.sort((a, b) => {
+    const rightA = this.getRight(a, rightName)
+    const rightB = this.getRight(b, rightName)
+    return rightA.price_in_cpu - rightB.price_in_cpu
+  })
+  return instruments 
+}
+
 async function getInstruments(params) {
   // Returns instruments indexed by owner/instrumentTemplate/instrumentClass
   // Returns all instruments by default
@@ -133,12 +143,8 @@ function sortInstruments(instruments, rightName, sortOrder = "cheapestThenMostRe
   switch (sortOrder) {
     case sortTypes[1]:
     
-      sortedInstruments = instruments.sort((a, b) => {
-        const rightA = this.getRight(a, rightName)
-        const rightB = this.getRight(b, rightName)
-        return rightA.price_in_cpu - rightB.price_in_cpu
-      })
-
+      sortedInstruments = sortByCheapestRight.bind(this)(instruments, rightName)
+      
       cheapestInstrument = sortedInstruments[0]
       cheapestPrice = this.getRight(cheapestInstrument, rightName).price_in_cpu;
       cheapestInstruments = sortedInstruments.filter(instrument => this.getRight(instrument, rightName).price_in_cpu === cheapestPrice)

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -22,8 +22,8 @@ function sortByMintedAt(instruments) {
   // minted_at represents the time when the instrument is either minted or updated
   instruments.sort((a, b) => {
     return a.instrument.minted_at - b.instrument.minted_at
-  })
-  return instruments
+  });
+  return instruments;
 }
 
 function sortByCheapestRight(instruments, rightName){
@@ -32,8 +32,8 @@ function sortByCheapestRight(instruments, rightName){
     const rightA = this.getRight(a, rightName)
     const rightB = this.getRight(b, rightName)
     return rightA.price_in_cpu - rightB.price_in_cpu
-  })
-  return instruments 
+  });
+  return instruments;
 }
 
 async function getInstruments(params) {
@@ -138,21 +138,21 @@ function sortInstruments(instruments, rightName, sortOrder = "cheapestThenMostRe
   const sortTypes = {
     1: "cheapestThenMostRecent",
     2: "mostRecent"
-  }
+  };
 
   switch (sortOrder) {
     case sortTypes[1]:
-      sortedInstruments = sortByCheapestRight.bind(this)(instruments, rightName)
-      cheapestInstrument = sortedInstruments[0]
+      sortedInstruments = sortByCheapestRight.bind(this)(instruments, rightName);
+      cheapestInstrument = sortedInstruments[0];
       cheapestPrice = this.getRight(cheapestInstrument, rightName).price_in_cpu;
-      cheapestInstruments = sortedInstruments.filter(instrument => this.getRight(instrument, rightName).price_in_cpu === cheapestPrice)
-      
-      sortedInstruments = sortByMintedAt(cheapestInstruments)
+      cheapestInstruments = sortedInstruments.filter(instrument => this.getRight(instrument, rightName).price_in_cpu === cheapestPrice);
+
+      sortedInstruments = sortByMintedAt(cheapestInstruments);
 
     case sortTypes[2]:    
-      sortedInstruments = sortByMintedAt(instruments)
+      sortedInstruments = sortByMintedAt(instruments);
   }
-  return sortedInstruments[sortedInstruments.length - 1]
+  return sortedInstruments[sortedInstruments.length - 1];
 }
 
 module.exports = {


### PR DESCRIPTION
- Move functionality to sort instrument from ore-client library to orejs
-  sort order for the instruments could either the cheapest (if more than one with same price, then returns the latest minted/updated instrument) or the most recently minted/updated

