### PR TITLE
keys are no longers stored on the config object

### DIFF
--- a/src/verifier.js
+++ b/src/verifier.js
@@ -3,11 +3,11 @@ const hash = require("hash.js")
 const ecc = require('eosjs-ecc')
 
 // sign the input data with the user keys
-async function sign(data) {
+function sign(data) {
     try {
-        return ecc.sign(data.toString(), this.config.privateKeys[0]);
+        return ecc.sign(data.toString(), this.signatureProvider.getAvailableKeys()[0])
     } catch(error) {
-        errorTitle = "Orejs Verifier Sign Error";
+        let errorTitle = "Orejs Verifier Sign Error";
         throw new Error(`${errorTitle}: ${error.message}`);
     }
 }

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -2,16 +2,6 @@ const fetch = require('node-fetch')
 const hash = require("hash.js")
 const ecc = require('eosjs-ecc')
 
-// sign the input data with the user keys
-function sign(data) {
-    try {
-        return ecc.sign(data.toString(), this.signatureProvider.getAvailableKeys()[0])
-    } catch(error) {
-        let errorTitle = "Orejs Verifier Sign Error";
-        throw new Error(`${errorTitle}: ${error.message}`);
-    }
-}
-
 // hash the parameter values to be sent to the verifier
 function hashParams(params) {
     let hashedParams = {}
@@ -75,7 +65,6 @@ async function getAccessTokenFromVerifier(verifierEndpoint, instrument, right, h
 }
 
 module.exports = {
-    sign,
     getAccessTokenFromVerifier,
     hashParams,
 }


### PR DESCRIPTION
@surabhil I was thinking that perhaps, instead of using this, which grabs the first available key, what we should be doing, is using the transact method, which will return transaction signatures for all keys in the signature provider....

`orejs.transact(actions, false)`

Setting broadcast to false will return transaction signatures. What do you think? Wanna give it a shot?