### PR TITLE
Feature/link custom actions

### DIFF
--- a/src/accounts.js
+++ b/src/accounts.js
@@ -164,13 +164,12 @@ async function appendPermission(oreAccountName, keys, permName, parent = 'active
   }
 }
 
-// TODO: Combine addPermission & addAndLinkAuthPermission with a parameter function
 async function addPermission(authAccountName, keys, permissionName, parentPermission, options = {}) {
   options = {
     authPermission: 'active',
     ...options
   }
-  const { authPermission } = options;
+  const { authPermission, links = [], broadcast = true } = options;
   const perm = await appendPermission.bind(this)(authAccountName, keys, permissionName, parentPermission);
   const { perm_name:permission, parent, required_auth:auth } = perm;
   const actions = [{
@@ -188,46 +187,32 @@ async function addPermission(authAccountName, keys, permissionName, parentPermis
     },
   }];
 
-  return this.transact(actions);
-}
-
-async function addAndLinkAuthPermission(oreAccountName, keys, permName, code, type, parentPermission = 'active', authPermission = 'owner', broadcast = true) {
-  const perm = await appendPermission.bind(this)(oreAccountName, keys, permName, parentPermission);
-  const { perm_name:permission, parent, required_auth:auth } = perm;
-  const actions = [{
-    account: 'eosio',
-    name: 'updateauth',
-    authorization: [{
-      actor: oreAccountName,
-      permission: authPermission,
-    }],
-    data: {
-      account: oreAccountName,
-      permission,
-      parent,
-      auth,
-    },
-  }, {
-    account: 'eosio',
-    name: 'linkauth',
-    authorization: [{
-      actor: oreAccountName,
-      permission: authPermission,
-    }],
-    data: {
-      account: oreAccountName,
-      code,
-      type,
-      requirement: permName,
-    },
-  }];
+  links.forEach(link => {
+    const { code, type } = link;
+    actions.push({
+      account: 'eosio',
+      name: 'linkauth',
+      authorization: [{
+        actor: authAccountName,
+        permission: authPermission,
+      }],
+      data: {
+        account: authAccountName,
+        code,
+        type,
+        requirement: permission,
+      }
+    });
+  });
 
   return this.transact(actions, broadcast);
 }
 
+// NOTE: This method is specific to creating authVerifier keys...
 async function generateAuthKeys(oreAccountName, permName, code, action, broadcast) {
   const authKeys = await Keygen.generateMasterKeys();
-  await addAndLinkAuthPermission.bind(this)(oreAccountName, [authKeys.publicKeys.active], permName, code, action, 'active', 'owner', broadcast);
+  const options = { broadcast, authPermission: 'owner', links: [{ code, action }] }
+  await addPermission.bind(this)(oreAccountName, [authKeys.publicKeys.active], permName, 'active', options);
   return authKeys;
 }
 

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -211,7 +211,7 @@ async function addPermission(authAccountName, keys, permissionName, parentPermis
 // NOTE: This method is specific to creating authVerifier keys...
 async function generateAuthKeys(oreAccountName, permName, code, action, broadcast) {
   const authKeys = await Keygen.generateMasterKeys();
-  const options = { broadcast, authPermission: 'owner', links: [{ code, action }] }
+  const options = { broadcast, authPermission: 'owner', links: [{ code, type: action }] }
   await addPermission.bind(this)(oreAccountName, [authKeys.publicKeys.active], permName, 'active', options);
   return authKeys;
 }

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -21,7 +21,7 @@ describe('account', () => {
   describe('createKeyPair', () => {
     let accountName = 'accountname';
     let parentPermission = 'active';
-    let options = {};
+    let options = { parentPermission };
 
     beforeEach(() => {
       mockGetAccount(orejs, false);
@@ -39,7 +39,7 @@ describe('account', () => {
       });
 
       it('returns a new key pair', async () => {
-        const keypair = await orejs.createKeyPair(WALLET_PASSWORD, USER_ACCOUNT_ENCRYPTION_SALT, accountName, permissionName, parentPermission, options);
+        const keypair = await orejs.createKeyPair(WALLET_PASSWORD, USER_ACCOUNT_ENCRYPTION_SALT, accountName, permissionName, options);
         expect(spyTransaction).toHaveBeenNthCalledWith(1, {
           actions: [
             mockAction({
@@ -80,7 +80,7 @@ describe('account', () => {
       });
 
       it('returns the existing and new key pair', async () => {
-        const keypair = await orejs.createKeyPair(WALLET_PASSWORD, USER_ACCOUNT_ENCRYPTION_SALT, accountName, permissionName, parentPermission, options);
+        const keypair = await orejs.createKeyPair(WALLET_PASSWORD, USER_ACCOUNT_ENCRYPTION_SALT, accountName, permissionName, options);
         expect(spyTransaction).toHaveBeenNthCalledWith(1, {
           actions: [
             mockAction({
@@ -131,7 +131,7 @@ describe('account', () => {
       });
 
       it('returns the existing key pair', async () => {
-        const keypair = await orejs.createKeyPair(WALLET_PASSWORD, USER_ACCOUNT_ENCRYPTION_SALT, accountName, permissionName, parentPermission, options);
+        const keypair = await orejs.createKeyPair(WALLET_PASSWORD, USER_ACCOUNT_ENCRYPTION_SALT, accountName, permissionName, options);
         expect(ecc.privateToPublic(orejs.decrypt(keypair.privateKeys.owner, WALLET_PASSWORD, USER_ACCOUNT_ENCRYPTION_SALT))).toEqual(keypair.publicKeys.owner);
         expect(keypair.publicKeys.owner).toEqual(keys.publicKeys.owner);
       });


### PR DESCRIPTION
* Required for passing in the propose action when creating new keys pairs for Everipedia
* Allow custom links to be passed in with new permissions
* Refactors authVerifier permissions to use the new addPermission method