### PR TITLE
Fix/migrate ore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/Open-Rights-Exchange/ore-js/tree/dev.svg?style=svg)](https://circleci.com/gh/Open-Rights-Exchange/ore-js)
+[![CircleCI](https://circleci.com/gh/Open-Rights-Exchange/ore-js.svg?style=svg)](https://circleci.com/gh/Open-Rights-Exchange/ore-js)
 
 # OREJS Spec
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/Open-Rights-Exchange/ore-js/tree/dev.svg?style=svg)](https://circleci.com/gh/Open-Rights-Exchange/ore-js/tree/dev)
+[![CircleCI](https://circleci.com/gh/Open-Rights-Exchange/ore-js/tree/dev.svg?style=svg)](https://circleci.com/gh/Open-Rights-Exchange/ore-js)
 
 # OREJS Spec
 

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -211,29 +211,6 @@ async function createAccount(password, salt, ownerPublicKey, orePayerAccountName
   };
 }
 
-async function createBridgeAccountWithKeys(authorizingAccount, keys, options) {
-  const { accountName, permission } = authorizingAccount;
-  const { origin, oreAccountName, contractName = 'createbridge', broadcast = true } = options;
-
-  const actions = [{
-    account: contractName,
-    name: 'create',
-    authorization: [{
-      actor: accountName,
-      permission,
-    }],
-    data: {
-      memo: accountName,
-      account: oreAccountName,
-      ownerkey: keys.publicKeys.owner,
-      activekey: keys.publicKeys.active,
-      origin
-    }
-  }];
-
-  return this.transact(actions, broadcast);
-}
-
 /* Public */
 
 async function addPermission(authAccountName, keys, permissionName, parentPermission, options = {}) {
@@ -313,10 +290,10 @@ async function createBridgeAccount(password, salt, authorizingAccount, options) 
 
   if (options.confirm) {
     transaction = await this.awaitTransaction(() => {
-      return createBridgeAccountWithKeys.bind(this)(authorizingAccount, keys, options);
+      return createNewAccount.bind(this)(authorizingAccount, keys, options);
     });
   } else {
-    transaction = await createBridgeAccountWithKeys.bind(this)(authorizingAccount, keys, options);
+    transaction = await createNewAccount.bind(this)(authorizingAccount, keys, options);
   }
 
   return {

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -290,10 +290,10 @@ async function createBridgeAccount(password, salt, authorizingAccount, options) 
 
   if (options.confirm) {
     transaction = await this.awaitTransaction(() => {
-      return createNewAccount.bind(this)(authorizingAccount, keys, options);
+      return this.createNewAccount(authorizingAccount, keys, options);
     });
   } else {
-    transaction = await createNewAccount.bind(this)(authorizingAccount, keys, options);
+    transaction = await this.createNewAccount(authorizingAccount, keys, options);
   }
 
   return {

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -221,29 +221,6 @@ async function createAccount(password, salt, ownerPublicKey, orePayerAccountName
   };
 }
 
-async function createBridgeAccountWithKeys(authorizingAccount, keys, options) {
-  const { accountName, permission } = authorizingAccount;
-  const { origin, oreAccountName, contractName = 'createbridge', broadcast = true } = options;
-
-  const actions = [{
-    account: contractName,
-    name: 'create',
-    authorization: [{
-      actor: accountName,
-      permission,
-    }],
-    data: {
-      memo: accountName,
-      account: oreAccountName,
-      ownerkey: keys.publicKeys.owner,
-      activekey: keys.publicKeys.active,
-      origin
-    }
-  }];
-
-  return this.transact(actions, broadcast);
-}
-
 /* Public */
 
 async function addPermission(authAccountName, keys, permissionName, parentPermission, options = {}) {
@@ -324,10 +301,10 @@ async function createBridgeAccount(password, salt, authorizingAccount, options) 
 
   if (options.confirm) {
     transaction = await this.awaitTransaction(() => {
-      return createBridgeAccountWithKeys.bind(this)(authorizingAccount, keys, options);
+      return createNewAccount.bind(this)(authorizingAccount, keys, options);
     });
   } else {
-    transaction = await createBridgeAccountWithKeys.bind(this)(authorizingAccount, keys, options);
+    transaction = await createNewAccount.bind(this)(authorizingAccount, keys, options);
   }
 
   const encryptedKeys = encryptKeys.bind(this)(keys, password, salt);

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -301,10 +301,10 @@ async function createBridgeAccount(password, salt, authorizingAccount, options) 
 
   if (options.confirm) {
     transaction = await this.awaitTransaction(() => {
-      return createNewAccount.bind(this)(authorizingAccount, keys, options);
+      return this.createNewAccount(authorizingAccount, keys, options);
     });
   } else {
-    transaction = await createNewAccount.bind(this)(authorizingAccount, keys, options);
+    transaction = await this.createNewAccount(authorizingAccount, keys, options);
   }
 
   const encryptedKeys = encryptKeys.bind(this)(keys, password, salt);

--- a/src/createbridge.js
+++ b/src/createbridge.js
@@ -156,7 +156,7 @@ function reclaim(authorizingAccount, appName, symbol, options){
     }],
     data: {
       reclaimer: accountName,
-      app: appName,
+      dapp: appName,
       sym: symbol,
     }
   }];

--- a/src/createbridge.js
+++ b/src/createbridge.js
@@ -69,6 +69,34 @@ function define(appAccount, appName, ram = 4096, net, cpu, options){
       return this.transact(actions, broadcast);
 }
 
+// Creates a new user account. It also airdrops custom dapp tokens to the new user account if an app owner has opted for airdrops
+// authorizingAccount = an object with account name and permission of the account paying for the balance left after getting the donation from the app contributors 
+// keys               = owner key and active key for the new account  
+// origin             = the string representing the app to create the new user account for. For ex- everipedia.org, lumeos
+async function createNewAccount(authorizingAccount, keys, options) {
+    const { accountName, permission } = authorizingAccount;
+    const { origin, oreAccountName, contractName = 'createbridge', broadcast = true } = options;
+  
+    const actions = [{
+      account: contractName,
+      name: 'create',
+      authorization: [{
+        actor: accountName,
+        permission,
+      }],
+      data: {
+        memo: accountName,
+        account: oreAccountName,
+        ownerkey: keys.publicKeys.owner,
+        activekey: keys.publicKeys.active,
+        origin
+      }
+    }];
+  
+    return this.transact(actions, broadcast);
+  }
+  
+
 // Contributes to account creation for an app by transferring the amount to createbridge with the app name in the memo field
 // contributor   = an object with account name and permission contributing towards an app
 // appName       = name of the app to contribute
@@ -125,6 +153,7 @@ function reclaim(appAccount, appName, symbol, options){
 
 module.exports = {
     init,
+    createNewAccount,
     define,
     transfer,
     reclaim

--- a/src/createbridge.js
+++ b/src/createbridge.js
@@ -1,0 +1,131 @@
+
+
+
+/* Public */
+
+// Initializes createbridge with the following details:
+// Only the createbridge account can call this action 
+// symbol               = the core token of the chain or the token used to pay for new user accounts of the chain  
+// precision            = precision of the core token of the chain 
+// newAccountContract   = the contract to call for new account action 
+// minimumRAM           = minimum bytes of RAM to put in a new account created on the chain 
+function init(symbol, precision, newAccountContract, minimumRAM, options){
+    const { contractName = "createbridge", permission = "active", broadcast = true} = options;
+    const chainSymbol = precision + "," + symbol;
+
+    const actions = [{
+        account: contractName,
+        name: 'init',
+        authorization: [{
+          actor: contractName,
+          permission,
+        }],
+        data: {
+            symbol: chainSymbol,
+            newaccountcontract: newAccountContract,
+            minimumram: minimumRAM,
+        }
+      }];
+    
+    return this.transact(actions, broadcast);
+}
+
+// Registers an app with the createbridge contract. Called with the following parameter:
+// appAccount       = an object with account name and permission to be registered as the owner of the app 
+// appName:         = the string/account name representing the app
+// ram:             = bytes of ram to put in the new user account created for the app (defaults to 4kb)
+// net              = amount to be staked for net
+// cpu              = amount to be staked for cpu
+// airdropContract  = name of the airdrop contract
+// airdropToken     = total number of tokens to be airdropped
+// airdroplimit     = number of tokens to be airdropped to the newly created account
+function define(appAccount, appName, ram = 4096, net, cpu, options){
+    const {airdropContract, airdropToken, airdropLimit, contractName = "createbridge", broadcast = true} = options;
+    const {accountName, permission = "active"} = appAccount;
+
+    const airdrop = {
+        contract: airdropContract,
+        tokens: airdropToken,
+        limit: airdropLimit
+    };
+
+    const actions = [{
+        account: contractName,
+        name: 'define',
+        authorization: [{
+          actor: accountName,
+          permission,
+        }],
+        data: {
+            owner: accountName,
+            dapp: appName,
+            ram_bytes: ram,
+            net,
+            cpu,
+            airdrop,
+        }
+      }];
+    
+      return this.transact(actions, broadcast);
+}
+
+// Contributes to account creation for an app by transferring the amount to createbridge with the app name in the memo field
+// contributor   = an object with account name and permission contributing towards an app
+// appName       = name of the app to contribute
+// amount        = amount to contribute
+// ramPercentage = RAM% per account the contributor wants to subsidize
+// totalAccounts = max accounts that can be created with the provided contribution (optional)
+function transfer(contributor , appName, amount, ramPercentage, totalAccounts=-1,options){
+    const { contractName = "eosio.token", createbridgeAccountName = "createbridge", broadcast = true } = options;
+    const { accountName, permission = "active" } = contributor;
+    const memo = appName + "," + ramPercentage + "," + totalAccounts;
+
+    const actions = [{
+        account: contractName,
+        name: 'transfer',
+        authorization: [{
+            actor: accountName,
+            permission,
+        }],
+        data: {
+            from: accountName,
+            to: createbridgeAccountName,
+            quantity: amount,
+            memo, 
+        }
+    }];
+
+    return this.transact(actions, broadcast);
+}
+
+// Transfers the remaining balance of a contributor from createbridge back to the contributor
+// appAccount = an object with account name and permission trying to reclaim the balance
+// appName    = the app name for which the account is trying to reclaim the balance
+// symbol     = symbol of the tokens to be reclaimed.
+function reclaim(appAccount, appName, symbol, options){
+    const { contractName = "createbridge", broadcast = true } = options;
+    const { accountName, permission = "active" } = appAccount
+
+    const actions = [{
+        account: contractName,
+        name: 'reclaim',
+        authorization: [{
+          actor: accountName,
+          permission,
+        }],
+        data: {
+            reclaimer: accountName,
+            dapp: appName,
+            sym: symbol,
+        }
+      }];
+      
+    return this.transact(actions, broadcast);
+}
+
+module.exports = {
+    init,
+    define,
+    transfer,
+    reclaim
+}

--- a/src/createbridge.js
+++ b/src/createbridge.js
@@ -1,6 +1,3 @@
-
-
-
 /* Public */
 
 // Initializes createbridge with the following details:
@@ -10,24 +7,23 @@
 // newAccountContract   = the contract to call for new account action 
 // minimumRAM           = minimum bytes of RAM to put in a new account created on the chain 
 function init(symbol, precision, newAccountContract, minimumRAM, options){
-    const { contractName = "createbridge", permission = "active", broadcast = true} = options;
-    const chainSymbol = precision + "," + symbol;
-
-    const actions = [{
-        account: contractName,
-        name: 'init',
-        authorization: [{
-          actor: contractName,
-          permission,
-        }],
-        data: {
-            symbol: chainSymbol,
-            newaccountcontract: newAccountContract,
-            minimumram: minimumRAM,
-        }
-      }];
+  const { contractName = "createbridge", permission = "active", broadcast = true } = options;
+  const chainSymbol = precision + "," + symbol;
+  const actions = [{
+    account: contractName,
+    name: 'init',
+    authorization: [{
+      actor: contractName,
+      permission,
+    }],
+    data: {
+      symbol: chainSymbol,
+      newaccountcontract: newAccountContract,
+      minimumram: minimumRAM,
+    }
+  }];
     
-    return this.transact(actions, broadcast);
+  return this.transact(actions, broadcast);
 }
 
 // Registers an app with the createbridge contract. Called with the following parameter:
@@ -40,33 +36,31 @@ function init(symbol, precision, newAccountContract, minimumRAM, options){
 // airdropToken             = total number of tokens to be airdropped
 // airdroplimit             = number of tokens to be airdropped to the newly created account
 function define(authorizingAccount, appName, ram = 4096, net, cpu, options){
-    const {airdropContract, airdropToken, airdropLimit, contractName = "createbridge", broadcast = true} = options;
-    const {accountName, permission = "active"} = authorizingAccount;
-
-    const airdrop = {
-        contract: airdropContract,
-        tokens: airdropToken,
-        limit: airdropLimit
-    };
-
-    const actions = [{
-        account: contractName,
-        name: 'define',
-        authorization: [{
-          actor: accountName,
-          permission,
-        }],
-        data: {
-            owner: accountName,
-            dapp: appName,
-            ram_bytes: ram,
-            net,
-            cpu,
-            airdrop,
-        }
-      }];
+  const { airdropContract, airdropToken, airdropLimit, contractName = "createbridge", broadcast = true } = options;
+  const { accountName, permission = "active" } = authorizingAccount;
+  const airdrop = {
+    contract: airdropContract,
+    tokens: airdropToken,
+    limit: airdropLimit
+  };
+  const actions = [{
+    account: contractName,
+    name: 'define',
+    authorization: [{
+      actor: accountName,
+      permission,
+    }],
+    data: {
+      owner: accountName,
+      dapp: appName,
+      ram_bytes: ram,
+      net,
+      cpu,
+      airdrop,
+    }
+  }];
     
-      return this.transact(actions, broadcast);
+  return this.transact(actions, broadcast);
 }
 
 // Creates a new user account. It also airdrops custom dapp tokens to the new user account if an app owner has opted for airdrops
@@ -74,49 +68,48 @@ function define(authorizingAccount, appName, ram = 4096, net, cpu, options){
 // keys               = owner key and active key for the new account  
 // origin             = the string representing the app to create the new user account for. For ex- everipedia.org, lumeos
 function createNewAccount(authorizingAccount, keys, options) {
-    const { accountName, permission } = authorizingAccount;
-    const { origin, oreAccountName, contractName = 'createbridge', broadcast = true } = options;
-    const actions = [{
-      account: contractName,
-      name: 'create',
-      authorization: [{
-        actor: accountName,
-        permission,
-      }],
-      data: {
-        memo: accountName,
-        account: oreAccountName,
-        ownerkey: keys.publicKeys.owner,
-        activekey: keys.publicKeys.active,
-        origin
-      }
-    }];
+  const { accountName, permission } = authorizingAccount;
+  const { origin, oreAccountName, contractName = 'createbridge', broadcast = true } = options;
+  const actions = [{
+    account: contractName,
+    name: 'create',
+    authorization: [{
+      actor: accountName,
+      permission,
+    }],
+    data: {
+      memo: accountName,
+      account: oreAccountName,
+      ownerkey: keys.publicKeys.owner,
+      activekey: keys.publicKeys.active,
+      origin
+    }
+  }];
   
-    return this.transact(actions, broadcast);
-  }
+  return this.transact(actions, broadcast);
+}
   
 // Owner account of an app can whitelist other accounts. 
 // authorizingAccount   = an object with account name and permission contributing towards an app
 // whitelistAccount     = account name to be whitelisted to create accounts on behalf of the app
 function whitelist(authorizingAccount, whitelistAccount, appName, options){
-    const { contractName = "createbridge", broadcast = true } = options;
-    const { accountName, permission = "active" } = authorizingAccount
+  const { contractName = "createbridge", broadcast = true } = options;
+  const { accountName, permission = "active" } = authorizingAccount
+  const actions = [{
+    account: contractName,
+    name: 'whitelist',
+    authorization: [{
+      actor: accountName,
+      permission,
+    }],
+    data: {
+      owner: accountName,
+      account: whitelistAccount,
+      dapp: appName,
+    }
+  }];
 
-    const actions = [{
-        account: contractName,
-        name: 'whitelist',
-        authorization: [{
-            actor: accountName,
-            permission,
-          }],
-          data: {
-              owner: accountName,
-              account: whitelistAccount,
-              dapp: appName,
-          }
-    }];
-
-    return this.transact(actions, broadcast);
+  return this.transact(actions, broadcast);
 }
 
 // Contributes to account creation for an app by transferring the amount to createbridge with the app name in the memo field
@@ -126,26 +119,25 @@ function whitelist(authorizingAccount, whitelistAccount, appName, options){
 // ramPercentage = RAM% per account the contributor wants to subsidize
 // totalAccounts = max accounts that can be created with the provided contribution (optional)
 function transfer(authorizingAccount , appName, amount, ramPercentage, totalAccounts=-1,options){
-    const { contractName = "eosio.token", createbridgeAccountName = "createbridge", broadcast = true } = options;
-    const { accountName, permission = "active" } = authorizingAccount;
-    const memo = appName + "," + ramPercentage + "," + totalAccounts;
+  const { contractName = "eosio.token", createbridgeAccountName = "createbridge", broadcast = true } = options;
+  const { accountName, permission = "active" } = authorizingAccount;
+  const memo = appName + "," + ramPercentage + "," + totalAccounts;
+  const actions = [{
+    account: contractName,
+    name: 'transfer',
+    authorization: [{
+      actor: accountName,
+      permission,
+    }],
+    data: {
+      from: accountName,
+      to: createbridgeAccountName,
+      quantity: amount,
+      memo, 
+    }
+  }];
 
-    const actions = [{
-        account: contractName,
-        name: 'transfer',
-        authorization: [{
-            actor: accountName,
-            permission,
-        }],
-        data: {
-            from: accountName,
-            to: createbridgeAccountName,
-            quantity: amount,
-            memo, 
-        }
-    }];
-
-    return this.transact(actions, broadcast);
+  return this.transact(actions, broadcast);
 }
 
 // Transfers the remaining balance of a contributor from createbridge back to the contributor
@@ -153,24 +145,23 @@ function transfer(authorizingAccount , appName, amount, ramPercentage, totalAcco
 // appName    = the app name for which the account is trying to reclaim the balance
 // symbol     = symbol of the tokens to be reclaimed.
 function reclaim(authorizingAccount, appName, symbol, options){
-    const { contractName = "createbridge", broadcast = true } = options;
-    const { accountName, permission = "active" } = authorizingAccount
-
-    const actions = [{
-        account: contractName,
-        name: 'reclaim',
-        authorization: [{
-          actor: accountName,
-          permission,
-        }],
-        data: {
-            reclaimer: accountName,
-            dapp: appName,
-            sym: symbol,
-        }
-      }];
+  const { contractName = "createbridge", broadcast = true } = options;
+  const { accountName, permission = "active" } = authorizingAccount
+  const actions = [{
+    account: contractName,
+    name: 'reclaim',
+    authorization: [{
+      actor: accountName,
+      permission,
+    }],
+    data: {
+      reclaimer: accountName,
+      app: appName,
+      sym: symbol,
+    }
+  }];
       
-    return this.transact(actions, broadcast);
+  return this.transact(actions, broadcast);
 }
 
 module.exports = {

--- a/src/createbridge.js
+++ b/src/createbridge.js
@@ -73,10 +73,9 @@ function define(authorizingAccount, appName, ram = 4096, net, cpu, options){
 // authorizingAccount = an object with account name and permission of the account paying for the balance left after getting the donation from the app contributors 
 // keys               = owner key and active key for the new account  
 // origin             = the string representing the app to create the new user account for. For ex- everipedia.org, lumeos
-async function createNewAccount(authorizingAccount, keys, options) {
+function createNewAccount(authorizingAccount, keys, options) {
     const { accountName, permission } = authorizingAccount;
     const { origin, oreAccountName, contractName = 'createbridge', broadcast = true } = options;
-  
     const actions = [{
       account: contractName,
       name: 'create',

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const eosjs = require('eosjs');
 const { TextDecoder, TextEncoder } = require('text-encoding');
 const accounts = require('./accounts');
 const cpu = require('./tokens/cpu');
+const creatbridge = require('./createbridge');
 const crypto = require('./modules/crypto');
 const eos = require('./eos');
 const instrument = require('./instrument');
@@ -19,6 +20,7 @@ class Orejs {
     /* Mixins */
     Object.assign(this, accounts);
     Object.assign(this, cpu);
+    Object.assign(this, creatbridge);
     Object.assign(this, crypto);
     Object.assign(this, eos);
     Object.assign(this, instrument);

--- a/src/tokens/ore.js
+++ b/src/tokens/ore.js
@@ -9,15 +9,6 @@ function issueOre(toAccountName, oreAmount, memo = '') {
   return this.issueToken(toAccountName, amount, ORE_ORE_ACCOUNT_NAME, CONTRACT_NAME, memo);
 }
 
-async function approveOre(fromAccountName, toAccountName, oreAmount, memo = '', permission = 'active') {
-  amount = this.getAmount(oreAmount, TOKEN_SYMBOL);
-  const fromAccountBalance = await this.getOreBalance(fromAccountName, TOKEN_SYMBOL, CONTRACT_NAME);
-  if (fromAccountBalance > 0) {
-    return this.approveTransfer(fromAccountName, toAccountName, amount, CONTRACT_NAME, memo, permission);
-  }
-  throw new Error('The account does not have sufficient balance');
-}
-
 function getOreBalance(oreAccountName) {
   return this.getBalance(oreAccountName, TOKEN_SYMBOL, CONTRACT_NAME);
 }
@@ -27,15 +18,8 @@ function transferOre(fromAccountName, toAccountName, oreAmount, memo = '') {
   return this.transferToken(fromAccountName, toAccountName, amount, CONTRACT_NAME, memo);
 }
 
-function transferOrefrom(approvedAccountName, fromAccountName, toAccountName, oreAmount, memo) {
-  amount = this.getAmount(oreAmount, TOKEN_SYMBOL);
-  return this.transferFrom(approvedAccountName, fromAccountName, toAccountName, amount, CONTRACT_NAME, memo);
-}
-
 module.exports = {
   issueOre,
-  approveOre,
   getOreBalance,
   transferOre,
-  transferOrefrom,
 };

--- a/src/tokens/ore.js
+++ b/src/tokens/ore.js
@@ -1,5 +1,5 @@
-const CONTRACT_NAME = 'token.ore';
-const ORE_ORE_ACCOUNT_NAME = 'ore.ore';
+const CONTRACT_NAME = 'eosio.token';
+const ORE_ORE_ACCOUNT_NAME = 'eosio';
 const TOKEN_SYMBOL = 'ORE';
 let amount;
 /* Public */

--- a/test/createbridge.test.js
+++ b/test/createbridge.test.js
@@ -2,8 +2,7 @@
 const { Keygen } = require('eosjs-keygen');
 const ecc = require('eosjs-ecc');
 const { mockAction, mockOptions } = require('./helpers/eos');
-const { constructOrejs, mockGetAccount, mockGetAccountWithAlreadyExistingAccount, mockGetInfo, mockGetBlock,
-  mockGetTransaction } = require('./helpers/orejs');
+const { constructOrejs, mockGetTransaction } = require('./helpers/orejs');
 
 describe('createbridge', () => {
   let spyTransaction;

--- a/test/createbridge.test.js
+++ b/test/createbridge.test.js
@@ -7,6 +7,12 @@ const { constructOrejs, mockGetAccount, mockGetAccountWithAlreadyExistingAccount
 
 describe('createbridge', () => {
   let spyTransaction;
+  let contractName = "createbridge";
+  let accountName = 'eosio';
+  let permission = 'active';
+  let authorizingAccount = {accountName, permission};
+  let appName = Math.random().toString();
+
 
   beforeAll(() => {
     orejs = constructOrejs();
@@ -19,8 +25,6 @@ describe('createbridge', () => {
     });
 
     it('initialises createbridge', () => {
-      const contractName = "createbridge";
-      const permission = 'active';
       const symbol = "SYS";
       const precision = 4;
       const newAccountContract = "eosio";
@@ -47,11 +51,6 @@ describe('createbridge', () => {
     });
 
     it('registers an app with createbridge', () => {
-        const contractName = "createbridge";
-        const accountName = 'eosio';
-        const permission = 'active';
-        const authorizingAccount = {accountName, permission};
-        const appName = Math.random().toString();
         const ram = 4096;
         const net = "1.0000 SYS";
         const cpu = "1.0000 SYS";
@@ -86,12 +85,7 @@ describe('createbridge', () => {
     });
 
     it('whitelist an account as a custodian for an app', () => {
-      const contractName = "createbridge";
-      const accountName = 'eosio';
-      const permission = 'active';
-      const authorizingAccount = {accountName, permission};
       const whitelistAccount = 'app.oreid';
-      const appName = Math.random().toString();
       const options = {contractName};
       orejs.whitelist(authorizingAccount, whitelistAccount, appName,options);
       expect(spyTransaction).toHaveBeenCalledWith({
@@ -113,11 +107,6 @@ describe('createbridge', () => {
     });
 
     it('transfers the contribution amount from the contributor to createbridge', () => {
-      const contractName = "eosio.token";
-      const accountName = 'eosio';
-      const permission = 'active';
-      const authorizingAccount = {accountName, permission};
-      const appName = Math.random().toString();
       const amount = "1.000 SYS";
       const ramPercentage = 50;
       const totalAccounts = 10;
@@ -143,11 +132,6 @@ describe('createbridge', () => {
     });
 
     it('reclaims the contributor\'s remaining core token balance from createbridge', () => {
-      const contractName = "createbridge";
-      const accountName = 'eosio';
-      const permission = 'active';
-      const authorizingAccount = {accountName, permission};
-      const appName = Math.random().toString();
       const symbol = 'SYS';
       const options = {contractName};
       orejs.reclaim(authorizingAccount, appName, symbol,options);
@@ -163,11 +147,6 @@ describe('createbridge', () => {
     })
 
     it('reclaims the contributor\'s remaining app token balance from createbridge', () => {
-      const contractName = "createbridge";
-      const accountName = 'eosio';
-      const permission = 'active';
-      const authorizingAccount = {accountName, permission};
-      const appName = Math.random().toString();
       // example app token
       const symbol = 'EX';
       const options = {contractName};

--- a/test/createbridge.test.js
+++ b/test/createbridge.test.js
@@ -1,0 +1,186 @@
+
+const { Keygen } = require('eosjs-keygen');
+const ecc = require('eosjs-ecc');
+const { mockAction, mockOptions } = require('./helpers/eos');
+const { constructOrejs, mockGetAccount, mockGetAccountWithAlreadyExistingAccount, mockGetInfo, mockGetBlock,
+  mockGetTransaction } = require('./helpers/orejs');
+
+describe('createbridge', () => {
+  let spyTransaction;
+
+  beforeAll(() => {
+    orejs = constructOrejs();
+  });
+
+  describe('init', () => {
+    beforeEach(() => {
+      transaction = mockGetTransaction(orejs);
+      spyTransaction = jest.spyOn(orejs.eos, 'transact');
+    });
+
+    it('initialises createbridge', () => {
+      const contractName = "createbridge";
+      const permission = 'active';
+      const symbol = "SYS";
+      const precision = 4;
+      const newAccountContract = "eosio";
+      const minimumRAM = 4096;
+      const options = {contractName};
+      orejs.init(symbol, precision, newAccountContract, minimumRAM, options);
+      expect(spyTransaction).toHaveBeenCalledWith({
+        actions: [
+          mockAction({account: contractName, name:"init", authorization: { actor: contractName, permission }, data:{
+            symbol: precision+","+symbol,
+            newaccountcontract: newAccountContract,
+            minimumram: minimumRAM,
+          }})
+        ]
+      },mockOptions());
+    });
+  });
+
+  describe('define', () => {
+
+    beforeEach(() => {
+      transaction = mockGetTransaction(orejs);
+      spyTransaction = jest.spyOn(orejs.eos, 'transact');
+    });
+
+    it('registers an app with createbridge', () => {
+        const contractName = "createbridge";
+        const accountName = 'eosio';
+        const permission = 'active';
+        const authorizingAccount = {accountName, permission};
+        const appName = Math.random().toString();
+        const ram = 4096;
+        const net = "1.0000 SYS";
+        const cpu = "1.0000 SYS";
+        const airdropContract = "";
+        const airdropToken = "0 SYS";
+        const airdropLimit = "0 SYS";
+        const options = {airdropContract, airdropToken, airdropLimit, contractName};
+        orejs.define(authorizingAccount, appName, ram, net, cpu, options);
+        expect(spyTransaction).toHaveBeenCalledWith({
+          actions: [
+            mockAction({account: contractName, name:"define", authorization: { permission }, data:{
+              owner: accountName,
+              dapp: appName,
+              ram_bytes: ram,
+              net: net,
+              cpu: cpu,
+              airdrop: {
+                contract: airdropContract,
+                tokens: airdropToken,
+                limit: airdropLimit
+              },
+            }})
+          ]
+        },mockOptions());
+      });
+  });
+
+  describe('whitelist', () => {
+    beforeEach(() => {
+      transaction = mockGetTransaction(orejs);
+      spyTransaction = jest.spyOn(orejs.eos, 'transact');
+    });
+
+    it('whitelist an account as a custodian for an app', () => {
+      const contractName = "createbridge";
+      const accountName = 'eosio';
+      const permission = 'active';
+      const authorizingAccount = {accountName, permission};
+      const whitelistAccount = 'app.oreid';
+      const appName = Math.random().toString();
+      const options = {contractName};
+      orejs.whitelist(authorizingAccount, whitelistAccount, appName,options);
+      expect(spyTransaction).toHaveBeenCalledWith({
+        actions: [
+          mockAction({account: contractName, name:"whitelist", authorization: { permission }, data:{
+            owner: accountName,
+            account: whitelistAccount,
+            dapp: appName,
+          }})
+        ]
+      },mockOptions()); 
+    });
+  });
+
+  describe('transfer', () => {
+    beforeEach(() => {
+      transaction = mockGetTransaction(orejs);
+      spyTransaction = jest.spyOn(orejs.eos, 'transact');
+    });
+
+    it('transfers the contribution amount from the contributor to createbridge', () => {
+      const contractName = "eosio.token";
+      const accountName = 'eosio';
+      const permission = 'active';
+      const authorizingAccount = {accountName, permission};
+      const appName = Math.random().toString();
+      const amount = "1.000 SYS";
+      const ramPercentage = 50;
+      const totalAccounts = 10;
+      const options = {contractName};
+      orejs.transfer(authorizingAccount, appName, amount, ramPercentage, totalAccounts,options);
+      expect(spyTransaction).toHaveBeenCalledWith({
+        actions: [
+          mockAction({account: contractName, name:"transfer", authorization: { permission }, data:{
+            from: accountName,
+            to: "createbridge",
+            quantity: amount,
+            memo: appName + "," + ramPercentage + "," + totalAccounts,
+          }})
+        ]
+      },mockOptions());
+    });
+  });
+
+  describe('reclaim', () => {
+    beforeEach(() => {
+      transaction = mockGetTransaction(orejs);
+      spyTransaction = jest.spyOn(orejs.eos, 'transact');
+    });
+
+    it('reclaims the contributor\'s remaining core token balance from createbridge', () => {
+      const contractName = "createbridge";
+      const accountName = 'eosio';
+      const permission = 'active';
+      const authorizingAccount = {accountName, permission};
+      const appName = Math.random().toString();
+      const symbol = 'SYS';
+      const options = {contractName};
+      orejs.reclaim(authorizingAccount, appName, symbol,options);
+      expect(spyTransaction).toHaveBeenCalledWith({
+        actions: [
+          mockAction({account: contractName, name:"reclaim", authorization: { permission }, data:{
+            reclaimer: accountName,
+            dapp: appName,
+            sym: symbol,  
+          }})
+        ]
+      },mockOptions());
+    })
+
+    it('reclaims the contributor\'s remaining app token balance from createbridge', () => {
+      const contractName = "createbridge";
+      const accountName = 'eosio';
+      const permission = 'active';
+      const authorizingAccount = {accountName, permission};
+      const appName = Math.random().toString();
+      // example app token
+      const symbol = 'EX';
+      const options = {contractName};
+      orejs.reclaim(authorizingAccount, appName, symbol,options);
+      expect(spyTransaction).toHaveBeenCalledWith({
+        actions: [
+          mockAction({account: contractName, name:"reclaim", authorization: { permission }, data:{
+            reclaimer: accountName,
+            dapp: appName,
+            sym: symbol,  
+          }})
+        ]
+      },mockOptions());
+    });
+  });
+});

--- a/test/tokens/ore.test.js
+++ b/test/tokens/ore.test.js
@@ -29,43 +29,6 @@ describe('ore', () => {
     });
   });
 
-  describe('approveOre', () => {
-    let oreBalance;
-    let memo;
-    let spyTransaction;
-    let transaction;
-
-    beforeEach(() => {
-      oreBalance = 10;
-      memo = 'approve ORE transfer';
-      fetch.resetMocks();
-      fetch.mockResponses(mock([`${oreBalance}.0000 ORE`]));
-      orejs = constructOrejs({ fetch });
-      transaction = mockGetTransaction(orejs);
-      spyTransaction = jest.spyOn(orejs.eos, 'transact');
-    });
-
-    describe('when authorized', () => {
-      it('returns', async () => {
-        mockGetInfo(orejs);
-        mockGetBlock(orejs);
-        const result = await orejs.approveOre(ORE_OWNER_ACCOUNT_NAME, ORE_TESTA_ACCOUNT_NAME, oreBalance, memo);
-        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'eosio.token', name: 'approve' })] }, mockOptions());
-      });
-    });
-
-    describe('when unauthorized', () => {
-      xit('throws', () => {
-        mockGetInfo(orejs);
-        mockGetBlock(orejs);
-        contract.approve.mockImplementationOnce(() => Promise.reject(new Error('unauthorized')));
-
-        const result = orejs.approveOre(ORE_TESTA_ACCOUNT_NAME, ORE_TESTA_ACCOUNT_NAME, oreBalance);
-        expect(result).rejects.toThrow(/unauthorized/);
-      });
-    });
-  });
-
   describe('transferOre', () => {
     let oreBalance;
     let spyTransaction;

--- a/test/tokens/ore.test.js
+++ b/test/tokens/ore.test.js
@@ -50,7 +50,7 @@ describe('ore', () => {
         mockGetInfo(orejs);
         mockGetBlock(orejs);
         const result = await orejs.approveOre(ORE_OWNER_ACCOUNT_NAME, ORE_TESTA_ACCOUNT_NAME, oreBalance, memo);
-        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'token.ore', name: 'approve' })] }, mockOptions());
+        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'eosio.token', name: 'approve' })] }, mockOptions());
       });
     });
 
@@ -80,7 +80,7 @@ describe('ore', () => {
     describe('when authorized', () => {
       it('returns', async () => {
         const result = await orejs.transferOre(ORE_OWNER_ACCOUNT_NAME, ORE_TESTA_ACCOUNT_NAME, oreBalance);
-        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'token.ore', name: 'transfer' })] }, mockOptions());
+        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'eosio.token', name: 'transfer' })] }, mockOptions());
       });
     });
 


### PR DESCRIPTION
- Use eosio.token contract for ORE instead of token.ore
- Update tests
- Since ORE is now a standard token, it doesn't have approve and transferfrom functionalities