### PR TITLE
Fix/migrate ore

### DIFF
--- a/src/createbridge.js
+++ b/src/createbridge.js
@@ -156,7 +156,7 @@ function reclaim(authorizingAccount, appName, symbol, options){
     }],
     data: {
       reclaimer: accountName,
-      app: appName,
+      dapp: appName,
       sym: symbol,
     }
   }];

--- a/src/tokens/ore.js
+++ b/src/tokens/ore.js
@@ -9,15 +9,6 @@ function issueOre(toAccountName, oreAmount, memo = '') {
   return this.issueToken(toAccountName, amount, ORE_ORE_ACCOUNT_NAME, CONTRACT_NAME, memo);
 }
 
-async function approveOre(fromAccountName, toAccountName, oreAmount, memo = '', permission = 'active') {
-  amount = this.getAmount(oreAmount, TOKEN_SYMBOL);
-  const fromAccountBalance = await this.getOreBalance(fromAccountName, TOKEN_SYMBOL, CONTRACT_NAME);
-  if (fromAccountBalance > 0) {
-    return this.approveTransfer(fromAccountName, toAccountName, amount, CONTRACT_NAME, memo, permission);
-  }
-  throw new Error('The account does not have sufficient balance');
-}
-
 function getOreBalance(oreAccountName) {
   return this.getBalance(oreAccountName, TOKEN_SYMBOL, CONTRACT_NAME);
 }
@@ -27,15 +18,8 @@ function transferOre(fromAccountName, toAccountName, oreAmount, memo = '') {
   return this.transferToken(fromAccountName, toAccountName, amount, CONTRACT_NAME, memo);
 }
 
-function transferOrefrom(approvedAccountName, fromAccountName, toAccountName, oreAmount, memo) {
-  amount = this.getAmount(oreAmount, TOKEN_SYMBOL);
-  return this.transferFrom(approvedAccountName, fromAccountName, toAccountName, amount, CONTRACT_NAME, memo);
-}
-
 module.exports = {
   issueOre,
-  approveOre,
   getOreBalance,
   transferOre,
-  transferOrefrom,
 };

--- a/src/tokens/ore.js
+++ b/src/tokens/ore.js
@@ -1,5 +1,5 @@
-const CONTRACT_NAME = 'token.ore';
-const ORE_ORE_ACCOUNT_NAME = 'ore.ore';
+const CONTRACT_NAME = 'eosio.token';
+const ORE_ORE_ACCOUNT_NAME = 'eosio';
 const TOKEN_SYMBOL = 'ORE';
 let amount;
 /* Public */

--- a/test/tokens/ore.test.js
+++ b/test/tokens/ore.test.js
@@ -29,43 +29,6 @@ describe('ore', () => {
     });
   });
 
-  describe('approveOre', () => {
-    let oreBalance;
-    let memo;
-    let spyTransaction;
-    let transaction;
-
-    beforeEach(() => {
-      oreBalance = 10;
-      memo = 'approve ORE transfer';
-      fetch.resetMocks();
-      fetch.mockResponses(mock([`${oreBalance}.0000 ORE`]));
-      orejs = constructOrejs({ fetch });
-      transaction = mockGetTransaction(orejs);
-      spyTransaction = jest.spyOn(orejs.eos, 'transact');
-    });
-
-    describe('when authorized', () => {
-      it('returns', async () => {
-        mockGetInfo(orejs);
-        mockGetBlock(orejs);
-        const result = await orejs.approveOre(ORE_OWNER_ACCOUNT_NAME, ORE_TESTA_ACCOUNT_NAME, oreBalance, memo);
-        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'eosio.token', name: 'approve' })] }, mockOptions());
-      });
-    });
-
-    describe('when unauthorized', () => {
-      xit('throws', () => {
-        mockGetInfo(orejs);
-        mockGetBlock(orejs);
-        contract.approve.mockImplementationOnce(() => Promise.reject(new Error('unauthorized')));
-
-        const result = orejs.approveOre(ORE_TESTA_ACCOUNT_NAME, ORE_TESTA_ACCOUNT_NAME, oreBalance);
-        expect(result).rejects.toThrow(/unauthorized/);
-      });
-    });
-  });
-
   describe('transferOre', () => {
     let oreBalance;
     let spyTransaction;

--- a/test/tokens/ore.test.js
+++ b/test/tokens/ore.test.js
@@ -50,7 +50,7 @@ describe('ore', () => {
         mockGetInfo(orejs);
         mockGetBlock(orejs);
         const result = await orejs.approveOre(ORE_OWNER_ACCOUNT_NAME, ORE_TESTA_ACCOUNT_NAME, oreBalance, memo);
-        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'token.ore', name: 'approve' })] }, mockOptions());
+        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'eosio.token', name: 'approve' })] }, mockOptions());
       });
     });
 
@@ -80,7 +80,7 @@ describe('ore', () => {
     describe('when authorized', () => {
       it('returns', async () => {
         const result = await orejs.transferOre(ORE_OWNER_ACCOUNT_NAME, ORE_TESTA_ACCOUNT_NAME, oreBalance);
-        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'token.ore', name: 'transfer' })] }, mockOptions());
+        expect(spyTransaction).toHaveBeenCalledWith({ actions: [mockAction({ account: 'eosio.token', name: 'transfer' })] }, mockOptions());
       });
     });
 


### PR DESCRIPTION
- Use eosio.token contract for ORE instead of token.ore
- Update tests
- Since ORE is now a standard token, it doesn't have approve and transferfrom functionalities