### PR TITLE
Feature/recycle accounts when needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-rights-exchange/orejs",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Orejs is a Javascript helper library to provide simple high-level access to the ore-protocol. Orejs uses eosJS as a wrapper to the EOS blockchain.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -209,8 +209,7 @@ async function createAccount(password, salt, ownerPublicKey, orePayerAccountName
     broadcast: true,
     ...options
   };
-  const { broadcast } = options;
-
+  const { broadcast, oreAccountName: newAccountName } = options;
   const {
     oreAccountName, transaction, keys
   } = await generateOreAccountAndEncryptedKeys.bind(this)(password, salt, ownerPublicKey, orePayerAccountName, options);
@@ -365,57 +364,50 @@ async function createBridgeAccount(password, salt, authorizingAccount, options) 
   let oreAccountName = null;
   let isAccountUsable = false;
   let transaction = null;
-  let transactionOptions;
-  let nameAlreadyExists = true;
 
   const { confirm = true, oreAccountName: newAccountName } = options;
   const keys = await generateEncryptedKeys.bind(this)(password, salt, options.keys);
+  const nameAlreadyExists = await getNameAlreadyExists.bind(this)(newAccountName);
 
-  if (!this.isNullOrEmpty(newAccountName)) {
-    nameAlreadyExists = await getNameAlreadyExists.bind(this)(newAccountName);
-  }
-
-  if (!this.isNullOrEmpty(newAccountName)) {
-    // add the new active key to the newAccountName if the account name exists already on the chain with the active key set to unusedAccountPubKey
+  // if the new account name passed in already exists, check if the active key matches the unused active public key
+  if (!this.isNullOrEmpty(newAccountName) && nameAlreadyExists) {
+    oreAccountName = newAccountName;
     try {
       isAccountUsable = await checkIfAccountNameUsable.bind(this)(newAccountName);
       if (isAccountUsable) {
-        oreAccountName = newAccountName;
-        transactionOptions = {
-          oreAccountName,
-          confirm,
-          ...options
-        };
-        transaction = await reuseAccount.bind(this)(oreAccountName, keys, 'owner', 'owner', 'active', transactionOptions);
+        transaction = await reuseAccount.bind(this)(oreAccountName, keys, 'owner', 'owner', 'active', options);
       }
     } catch (error) {
       throw new Error(`Error creating bridge account: Provided account name cannot be used for the new account:  ${newAccountName} ${error}`);
     }
-  } else {
-    // call create new account if the new account name doesn't exist on chain or is null/undefined
+  }
+
+  // if no new account name is passed in, generate a new account name and create it
+  // or if the new account name passed in doesn't exist on chain yet, create the account
+  if (!nameAlreadyExists || this.isNullOrEmpty(newAccountName)) {
     try {
-      if (!nameAlreadyExists) {
+      if (!this.isNullOrEmpty(newAccountName) && !nameAlreadyExists) {
         oreAccountName = newAccountName;
       } else {
         oreAccountName = await generateAccountName.bind(this)(options.accountNamePrefix);
       }
-
-      transactionOptions = {
+      options = {
+        ...options,
         oreAccountName,
-        confirm,
-        ...options
+        confirm
       };
 
       if (confirm) {
         const awaitTransactionOptions = getAwaitTransactionOptions(options);
-        transaction = await this.awaitTransaction(async () => this.createNewAccount(authorizingAccount, keys, transactionOptions), awaitTransactionOptions);
+        transaction = await this.awaitTransaction(async () => this.createNewAccount(authorizingAccount, keys, options), awaitTransactionOptions);
       } else {
-        transaction = await this.createNewAccount(authorizingAccount, keys, transactionOptions);
+        transaction = await this.createNewAccount(authorizingAccount, keys, options);
       }
     } catch (error) {
       throw new Error(`Error creating bridge account: ${newAccountName} ${error}`);
     }
   }
+
   return {
     oreAccountName,
     privateKey: keys.privateKeys.active,
@@ -427,18 +419,69 @@ async function createBridgeAccount(password, salt, authorizingAccount, options) 
 
 // Creates an account, with verifier auth keys for ORE, and without for EOS
 async function createOreAccount(password, salt, ownerPublicKey, orePayerAccountName, options = {}) {
-  const { broadcast } = options;
+  let oreAccountName = null;
+  let isAccountUsable = false;
+  let transaction = null;
+  let verifierAuthKey = null;
+  let verifierAuthPublicKey = null;
+  let nameAlreadyExists = true;
 
-  const returnInfo = await createAccount.bind(this)(password, salt, ownerPublicKey, orePayerAccountName, options);
+  let keys = await generateEncryptedKeys.bind(this)(password, salt, options.keys);
 
-  if (this.chainName === 'ore') {
-    const verifierAuthKeys = await generateAuthKeys.bind(this)(returnInfo.oreAccountName, 'authverifier', 'token.ore', 'approve', broadcast);
+  const { broadcast, confirm = true, oreAccountName: newAccountName } = options;
 
-    returnInfo.verifierAuthKey = verifierAuthKeys.privateKeys.active;
-    returnInfo.verifierAuthPublicKey = verifierAuthKeys.publicKeys.active;
+  if (!this.isNullOrEmpty(newAccountName)) {
+    oreAccountName = newAccountName;
+    nameAlreadyExists = await getNameAlreadyExists.bind(this)(newAccountName);
+    // if the new account name already exists, check if the active key matches the unused active public key
+    if (nameAlreadyExists) {
+      try {
+        isAccountUsable = await checkIfAccountNameUsable.bind(this)(newAccountName);
+        if (isAccountUsable) {
+          transaction = await reuseAccount.bind(this)(oreAccountName, keys, 'owner', 'owner', 'active', options);
+        }
+      } catch (error) {
+        throw new Error(`Error creating account: Provided account name cannot be used for the new account:  ${newAccountName} ${error}`);
+      }
+    } else {
+      // if the new account name doesn't exist, create it
+      try {
+        const { active: activePublicKey } = keys.publicKeys;
+        if (confirm) {
+          const awaitTransactionOptions = getAwaitTransactionOptions(options);
+          transaction = await this.awaitTransaction(() => newAccountTransaction.bind(this)(oreAccountName, ownerPublicKey, activePublicKey, orePayerAccountName, options), awaitTransactionOptions);
+        } else {
+          transaction = await newAccountTransaction.bind(this)(oreAccountName, ownerPublicKey, activePublicKey, orePayerAccountName, options);
+        }
+        if (this.chainName === 'ore') {
+          const verifierAuthKeys = await generateAuthKeys.bind(this)(oreAccountName, 'authverifier', 'token.ore', 'approve', broadcast);
+          verifierAuthKey = verifierAuthKeys.privateKeys.active;
+          verifierAuthPublicKey = verifierAuthKeys.publicKeys.active;
+        }
+      } catch (error) {
+        throw new Error(`Error creating account: ${newAccountName} ${error}`);
+      }
+    }
+  } else {
+    const returnInfo = await createAccount.bind(this)(password, salt, ownerPublicKey, orePayerAccountName, options);
+    ({ oreAccountName, keys, transaction } = returnInfo);
+
+    if (this.chainName === 'ore') {
+      const verifierAuthKeys = await generateAuthKeys.bind(this)(oreAccountName, 'authverifier', 'token.ore', 'approve', broadcast);
+      verifierAuthKey = verifierAuthKeys.privateKeys.active;
+      verifierAuthPublicKey = verifierAuthKeys.publicKeys.active;
+    }
   }
 
-  return returnInfo;
+  return {
+    oreAccountName,
+    privateKey: keys.privateKeys.active,
+    publicKey: keys.publicKeys.active,
+    keys,
+    transaction,
+    verifierAuthKey,
+    verifierAuthPublicKey
+  };
 }
 
 function eosBase32(base32String) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,20 @@
+function isNullOrEmpty(obj) {
+  if (obj === undefined) {
+    return true;
+  }
+  if (obj === null) {
+    return true;
+  }
+  // Check for an empty array too
+  // eslint-disable-next-line no-prototype-builtins
+  if (obj.hasOwnProperty('length')) {
+    if (obj.length === 0) {
+      return true;
+    }
+  }
+  return (Object.keys(obj).length === 0 && obj.constructor === Object);
+}
+
+module.exports = {
+  isNullOrEmpty
+};

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const cpu = require('./tokens/cpu');
 const createbridge = require('./createbridge');
 const crypto = require('./modules/crypto');
 const eos = require('./eos');
+const helpers = require('./helpers');
 const instrument = require('./instrument');
 const ore = require('./tokens/ore');
 const oreStandardToken = require('./orestandardtoken');
@@ -25,6 +26,7 @@ class Orejs {
     Object.assign(this, createbridge);
     Object.assign(this, crypto);
     Object.assign(this, eos);
+    Object.assign(this, helpers);
     Object.assign(this, instrument);
     Object.assign(this, ore);
     Object.assign(this, oreStandardToken);
@@ -36,6 +38,7 @@ class Orejs {
   constructEos(config) {
     this.config = config;
     this.chainName = config.chainName || 'ore'; // ore || eos
+    this.unusedAccountPubKey = config.unusedAccountPubKey || null;
     this.rpc = new JsonRpc(config.httpEndpoint, { fetch: config.fetch || fetch });
     this.signatureProvider = config.signatureProvider || new JsSignatureProvider(config.privateKeys || []);
     this.eos = new Api({

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -44,7 +44,7 @@ describe('account', () => {
       });
 
       it('returns the transaction', async () => {
-        const permissionTransaction = await orejs.addPermission(accountName, [keys.publicKeys.active], permissionName, parentPermission, options);
+        const permissionTransaction = await orejs.addPermission(accountName, [keys.publicKeys.active], permissionName, parentPermission, false, options);
         expect(spyTransaction).toHaveBeenNthCalledWith(1, {
           actions: [
             mockAction({


### PR DESCRIPTION
- Use the new account name if passed in and matched the unused account public key
- Use the new account name if passed in and  it doesn't exist on chain yet
- Attach unused public key to orejs config
- Generate  a new account name if no account name passed in
- Add helper function to check null or empty
- Keep orejs function interfaces the same so it doesn't break api.market